### PR TITLE
Handle case where Channels provides None as the code

### DIFF
--- a/channels_graphql_ws/graphql_ws.py
+++ b/channels_graphql_ws/graphql_ws.py
@@ -659,7 +659,9 @@ class GraphqlWsConsumer(ch_websocket.AsyncJsonWebsocketConsumer):
         # connection close code. We consider all reserver codes (<999),
         # 1000 "Normal Closure", and 1001 "Going Away" as OK.
         # See: https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
-        if code <= 1001:
+        if not code:
+            log.warning("WebSocket connection closed without a code")
+        elif code <= 1001:
             log.debug("WebSocket connection closed with code: %s.", code)
         else:
             log.warning("WebSocket connection closed with code: %s!", code)


### PR DESCRIPTION
Sometimes, a disconnection leads to Channels providing `None` as the disconnect code. The conditional log statement then generates an exception, causing the rest of the disconnect handler to fail to run.

This PR adds a simple guard which ensures that a code is passed in so that an exception will not be generated by attempting to log data which is not present.