### PR TITLE
Per-operation context + initial payload

### DIFF
--- a/channels_graphql_ws/graphql_ws_consumer.py
+++ b/channels_graphql_ws/graphql_ws_consumer.py
@@ -58,7 +58,7 @@ import graphql.execution.executors.asyncio
 import promise
 import rx
 
-from .scope_as_context import ScopeAsContext
+from .operation_context import OperationContext
 from .serializer import Serializer
 
 # Module logger.
@@ -547,7 +547,7 @@ class GraphqlWsConsumer(ch_websocket.AsyncJsonWebsocketConsumer):
 
             # Create object-like context (like in `Query` or `Mutation`)
             # from the dict-like one provided by the Channels.
-            context = ScopeAsContext(self.scope)
+            context = OperationContext(self.scope)
 
             # Adding channel name to the context because it seems to be
             # useful for some use cases, take a loot at the issue from

--- a/channels_graphql_ws/graphql_ws_consumer.py
+++ b/channels_graphql_ws/graphql_ws_consumer.py
@@ -671,7 +671,12 @@ class GraphqlWsConsumer(ch_websocket.AsyncJsonWebsocketConsumer):
                 await self._send_gql_complete(operation_id)
 
     async def _register_subscription(
-        self, operation_id, groups, publish_callback, unsubscribed_callback
+        self,
+        operation_id,
+        groups,
+        publish_callback,
+        unsubscribed_callback,
+        initial_payload,
     ):
         """Register a new subscription when client subscribes.
 
@@ -709,6 +714,10 @@ class GraphqlWsConsumer(ch_websocket.AsyncJsonWebsocketConsumer):
             maxsize=self.subscription_notification_queue_limit
         )
 
+        # Enqueue the initial payload.
+        if initial_payload is not self.SKIP:
+            notification_queue.put_nowait(Serializer.serialize(initial_payload))
+
         # Start an endless task which listens the `notification_queue`
         # and invokes subscription "resolver" on new notifications.
         async def notifier():
@@ -716,6 +725,14 @@ class GraphqlWsConsumer(ch_websocket.AsyncJsonWebsocketConsumer):
 
             # Assert we run in a proper thread.
             self._assert_thread()
+
+            # Dirty hack to partially workaround the race between:
+            #  1) call to `result.subscribe` in `_on_gql_start`; and
+            #  2) call to `trigger.on_next` below in this function.
+            # The first call must be earlier. Otherwise, first one or more notifications
+            # may be lost.
+            await asyncio.sleep(1)
+
             while True:
                 serialized_payload = await notification_queue.get()
 

--- a/channels_graphql_ws/operation_context.py
+++ b/channels_graphql_ws/operation_context.py
@@ -1,0 +1,33 @@
+"""Just `OperationContext` class."""
+
+from channels_graphql_ws.scope_as_context import ScopeAsContext
+
+
+class OperationContext(ScopeAsContext):
+    """
+    The context intended to use in methods of Graphene classes as `info.context`.
+
+    This class provides two public properties:
+    1. `scope` - per-connection context. This is the `scope` of Django Channels.
+    2. `operation_context` - per-operation context. Empty. Fill free to store your's
+       data here.
+
+    For backward compatibility:
+    - Method `_asdict` returns the `scope`.
+    - Other attributes are routed to the `scope`.
+    """
+
+    def __init__(self, scope: dict):
+        """Nothing interesting here."""
+        super().__init__(scope)
+        self._operation_context: dict = {}
+
+    @property
+    def scope(self) -> dict:
+        """Return the scope."""
+        return self._scope
+
+    @property
+    def operation_context(self) -> dict:
+        """Return the per-operation context."""
+        return self._operation_context

--- a/channels_graphql_ws/scope_as_context.py
+++ b/channels_graphql_ws/scope_as_context.py
@@ -25,7 +25,7 @@
 class ScopeAsContext:
     """Wrapper to make Channels `scope` appear as an `info.context`."""
 
-    def __init__(self, scope):
+    def __init__(self, scope: dict):
         """Remember given `scope`."""
         self._scope = scope
 

--- a/channels_graphql_ws/subscription.py
+++ b/channels_graphql_ws/subscription.py
@@ -356,6 +356,7 @@ class Subscription(graphene.ObjectType):
         _meta.subscribe = get_function(subscribe)
         _meta.publish = get_function(publish)
         _meta.unsubscribed = get_function(unsubscribed)
+        _meta.initial_payload = options.get("initial_payload", cls.SKIP)
 
         super().__init_subclass_with_meta__(_meta=_meta, **options)
 
@@ -422,7 +423,9 @@ class Subscription(graphene.ObjectType):
             # `subscribe`.
             return result
 
-        return register_subscription(groups, publish_callback, unsubscribed_callback)
+        return register_subscription(
+            groups, publish_callback, unsubscribed_callback, cls._meta.initial_payload
+        )
 
     @classmethod
     def _group_name(cls, group=None):

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -732,9 +732,9 @@ async def test_message_order_in_subscribe_unsubscribe_all_loop(
     'complete' message.
     """
 
-    NUMBER_OF_UNSUBSCRIBE_CALLS = 50  # pylint: disable=invalid-name
+    NUMBER_OF_UNSUBSCRIBE_CALLS = 100  # pylint: disable=invalid-name
     # Delay in seconds.
-    DELAY_BETWEEN_UNSUBSCRIBE_CALLS = 0.01  # pylint: disable=invalid-name
+    DELAY_BETWEEN_UNSUBSCRIBE_CALLS = 0.02  # pylint: disable=invalid-name
     # Gradually stop the test if time is up.
     TIME_BORDER = 20  # pylint: disable=invalid-name
 


### PR DESCRIPTION
This pull request adds two features:
1. https://github.com/datadvance/DjangoChannelsGraphqlWs/commit/e86c5fe7f46cbc1f1c5a918f994dc31b2e3ed599 Per-operation context - allows sharing any data between different calls to `Subscription.publish` for the same subscription (and the same connection).
2. https://github.com/datadvance/DjangoChannelsGraphqlWs/commit/39d61be0eb491338bfb1cbfc21928a09a24cd095 Initial payload - allows sending an arbitrary "initial" response to a client as soon as it is subscribed (before any call to `Subscription.broadcast`).

I use them like so (in `schema.py`):

~~~schema.py
import channels_graphql_ws
import graphene
from channels_graphql_ws.operation_context import OperationContext
from graphene import ResolveInfo

from .task import Task

class TaskLogChanged(channels_graphql_ws.Subscription):
    class Arguments:
        id = graphene.Argument(graphene.NonNull(graphene.ID))

    content = graphene.Field(graphene.NonNull(graphene.List(graphene.NonNull(graphene.String))))
    begin = graphene.Field(graphene.NonNull(graphene.Int))
    end = graphene.Field(graphene.NonNull(graphene.Int))

    class Meta:
        initial_payload = None

    @staticmethod
    def subscribe(root: None, info: ResolveInfo, id: str) -> Optional[List[str]]:
        task = Task(id)
        return [task.uuid]

    @classmethod
    def trigger(cls, task: Task) -> None:
        cls.broadcast_sync(group=task.uuid, payload=None)

    @staticmethod
    def publish(payload: None, info: ResolveInfo, id: str) -> Union[TaskLogChanged, object]:
        assert isinstance(info.context, OperationContext)
        saved_cursor: int = info.context.operation_context.get('cursor', 0)

        task = Task(id)
        content, new_cursor = task.get_log(saved_cursor)

        if new_cursor == saved_cursor:
            assert len(list(content)) == 0
            return TaskLogChanged.SKIP
        else:
            info.context.operation_context['cursor'] = new_cursor
            return TaskLogChanged(content=content, begin=saved_cursor, end=new_cursor)
~~~
