### PR TITLE
Per-operation context + initial payload

### DIFF
--- a/channels_graphql_ws/graphql_ws_consumer.py
+++ b/channels_graphql_ws/graphql_ws_consumer.py
@@ -713,9 +713,6 @@ class GraphqlWsConsumer(ch_websocket.AsyncJsonWebsocketConsumer):
         # `_sids_by_group` without any locks.
         self._assert_thread()
 
-        # The subject we will trigger on the `broadcast` message.
-        trigger = rx.subjects.Subject()
-
         # The subscription notification queue.
         queue_size = notification_queue_limit
         if not queue_size or queue_size < 0:
@@ -728,24 +725,16 @@ class GraphqlWsConsumer(ch_websocket.AsyncJsonWebsocketConsumer):
 
         # Start an endless task which listens the `notification_queue`
         # and invokes subscription "resolver" on new notifications.
-        async def notifier():
+        async def notifier(observer: rx.Observer):
             """Watch the notification queue and notify clients."""
 
             # Assert we run in a proper thread.
             self._assert_thread()
-
-            # Dirty hack to partially workaround the race between:
-            #  1) call to `result.subscribe` in `_on_gql_start`; and
-            #  2) call to `trigger.on_next` below in this function.
-            # The first call must be earlier. Otherwise, first one or more notifications
-            # may be lost.
-            await asyncio.sleep(1)
-
             while True:
                 serialized_payload = await notification_queue.get()
 
                 # Run a subscription's `publish` method (invoked by the
-                # `trigger.on_next` function) within the threadpool used
+                # `observer.on_next` function) within the threadpool used
                 # for processing other GraphQL resolver functions.
                 # NOTE: it is important to run the deserialization
                 # in the worker thread as well.
@@ -753,31 +742,24 @@ class GraphqlWsConsumer(ch_websocket.AsyncJsonWebsocketConsumer):
                     try:
                         payload = Serializer.deserialize(serialized_payload)
                     except Exception as ex:  # pylint: disable=broad-except
-                        trigger.on_error(f"Cannot deserialize payload. {ex}")
+                        observer.on_error(f"Cannot deserialize payload. {ex}")
                     else:
-                        trigger.on_next(payload)
+                        observer.on_next(payload)
 
                 await self._run_in_worker(workload)
 
                 # Message processed. This allows `Queue.join` to work.
                 notification_queue.task_done()
 
-        # Enqueue the `publish` method execution. But do not notify
-        # clients when `publish` returns `SKIP`.
-        stream = trigger.map(publish_callback).filter(  # pylint: disable=no-member
-            lambda publish_returned: publish_returned is not self.SKIP
-        )
-
+        def push_payloads(observer: rx.Observer):
             # Start listening for broadcasts (subscribe to the Channels
             # groups), spawn the notification processing task and put
             # subscription information into the registry.
             # NOTE: Update of `_sids_by_group` & `_subscriptions` must be
             # atomic i.e. without `awaits` in between.
-        waitlist = []
             for group in groups:
                 self._sids_by_group.setdefault(group, []).append(operation_id)
-            waitlist.append(self._channel_layer.group_add(group, self.channel_name))
-        notifier_task = self._spawn_background_task(notifier())
+            notifier_task = self._spawn_background_task(notifier(observer))
             self._subscriptions[operation_id] = self._SubInf(
                 groups=groups,
                 sid=operation_id,
@@ -786,9 +768,20 @@ class GraphqlWsConsumer(ch_websocket.AsyncJsonWebsocketConsumer):
                 notifier_task=notifier_task,
             )
 
-        await asyncio.wait(waitlist)
+        await asyncio.wait(
+            [
+                self._channel_layer.group_add(group, self.channel_name)
+                for group in groups
+            ]
+        )
 
-        return stream
+        # Enqueue the `publish` method execution. But do not notify
+        # clients when `publish` returns `SKIP`.
+        return (
+            rx.Observable.create(push_payloads)  # pylint: disable=no-member
+            .map(publish_callback)
+            .filter(lambda publish_returned: publish_returned is not self.SKIP)
+        )
 
     async def _on_gql_stop(self, operation_id):
         """Process the STOP message.

--- a/channels_graphql_ws/graphql_ws_consumer.py
+++ b/channels_graphql_ws/graphql_ws_consumer.py
@@ -58,7 +58,7 @@ import graphql.execution.executors.asyncio
 import promise
 import rx
 
-from .scope_as_context import ScopeAsContext
+from .operation_context import OperationContext
 from .serializer import Serializer
 
 # Module logger.
@@ -550,7 +550,7 @@ class GraphqlWsConsumer(ch_websocket.AsyncJsonWebsocketConsumer):
 
             # Create object-like context (like in `Query` or `Mutation`)
             # from the dict-like one provided by the Channels.
-            context = ScopeAsContext(self.scope)
+            context = OperationContext(self.scope)
 
             # Adding channel name to the context because it seems to be
             # useful for some use cases, take a loot at the issue from

--- a/channels_graphql_ws/graphql_ws_consumer.py
+++ b/channels_graphql_ws/graphql_ws_consumer.py
@@ -728,15 +728,23 @@ class GraphqlWsConsumer(ch_websocket.AsyncJsonWebsocketConsumer):
             # Assert we run in a proper thread.
             self._assert_thread()
             while True:
-                payload = await notification_queue.get()
+                serialized_payload = await notification_queue.get()
+
                 # Run a subscription's `publish` method (invoked by the
                 # `trigger.on_next` function) within the threadpool used
                 # for processing other GraphQL resolver functions.
-                # NOTE: `lambda` is important to run the deserialization
+                # NOTE: it is important to run the deserialization
                 # in the worker thread as well.
-                await self._run_in_worker(
-                    lambda: trigger.on_next(Serializer.deserialize(payload))
-                )
+                def workload():
+                    try:
+                        payload = Serializer.deserialize(serialized_payload)
+                    except Exception as ex:  # pylint: disable=broad-except
+                        trigger.on_error(f"Cannot deserialize payload. {ex}")
+                    else:
+                        trigger.on_next(payload)
+
+                await self._run_in_worker(workload)
+
                 # Message processed. This allows `Queue.join` to work.
                 notification_queue.task_done()
 
@@ -746,23 +754,23 @@ class GraphqlWsConsumer(ch_websocket.AsyncJsonWebsocketConsumer):
             lambda publish_returned: publish_returned is not self.SKIP
         )
 
-        # Start listening for broadcasts (subscribe to the Channels
-        # groups), spawn the notification processing task and put
-        # subscription information into the registry.
-        # NOTE: Update of `_sids_by_group` & `_subscriptions` must be
-        # atomic i.e. without `awaits` in between.
+            # Start listening for broadcasts (subscribe to the Channels
+            # groups), spawn the notification processing task and put
+            # subscription information into the registry.
+            # NOTE: Update of `_sids_by_group` & `_subscriptions` must be
+            # atomic i.e. without `awaits` in between.
         waitlist = []
-        for group in groups:
-            self._sids_by_group.setdefault(group, []).append(operation_id)
+            for group in groups:
+                self._sids_by_group.setdefault(group, []).append(operation_id)
             waitlist.append(self._channel_layer.group_add(group, self.channel_name))
         notifier_task = self._spawn_background_task(notifier())
-        self._subscriptions[operation_id] = self._SubInf(
-            groups=groups,
-            sid=operation_id,
-            unsubscribed_callback=unsubscribed_callback,
-            notification_queue=notification_queue,
-            notifier_task=notifier_task,
-        )
+            self._subscriptions[operation_id] = self._SubInf(
+                groups=groups,
+                sid=operation_id,
+                unsubscribed_callback=unsubscribed_callback,
+                notification_queue=notification_queue,
+                notifier_task=notifier_task,
+            )
 
         await asyncio.wait(waitlist)
 

--- a/channels_graphql_ws/operation_context.py
+++ b/channels_graphql_ws/operation_context.py
@@ -1,0 +1,33 @@
+"""Just `OperationContext` class."""
+
+from channels_graphql_ws.scope_as_context import ScopeAsContext
+
+
+class OperationContext(ScopeAsContext):
+    """
+    The context intended to use in methods of Graphene classes as `info.context`.
+
+    This class provides two public properties:
+    1. `scope` - per-connection context. This is the `scope` of Django Channels.
+    2. `operation_context` - per-operation context. Empty. Fill free to store your's
+       data here.
+
+    For backward compatibility:
+    - Method `_asdict` returns the `scope`.
+    - Other attributes are routed to the `scope`.
+    """
+
+    def __init__(self, scope: dict):
+        """Nothing interesting here."""
+        super().__init__(scope)
+        self._operation_context: dict = {}
+
+    @property
+    def scope(self) -> dict:
+        """Return the scope."""
+        return self._scope
+
+    @property
+    def operation_context(self) -> dict:
+        """Return the per-operation context."""
+        return self._operation_context

--- a/channels_graphql_ws/scope_as_context.py
+++ b/channels_graphql_ws/scope_as_context.py
@@ -25,7 +25,7 @@
 class ScopeAsContext:
     """Wrapper to make Channels `scope` appear as an `info.context`."""
 
-    def __init__(self, scope):
+    def __init__(self, scope: dict):
         """Remember given `scope`."""
         self._scope = scope
 

--- a/channels_graphql_ws/subscription.py
+++ b/channels_graphql_ws/subscription.py
@@ -148,6 +148,11 @@ class Subscription(graphene.ObjectType):
     # Return this from the `publish` to suppress the notification.
     SKIP = GraphqlWsConsumer.SKIP
 
+    # Initial payload. Set it to send an "initial" response with this
+    # payload to a client as soon as it is subscribed (before any call
+    # to `Subscription.broadcast`).
+    initial_payload = GraphqlWsConsumer.SKIP
+
     # Subscription notifications queue limit. Set this to control the
     # amount of notifications server keeps in queue when notifications
     # come faster than server processing them. Set this limit to 1 drops
@@ -435,6 +440,7 @@ class Subscription(graphene.ObjectType):
             groups,
             publish_callback,
             unsubscribed_callback,
+            cls.initial_payload,
             cls.notification_queue_limit,
         )
 

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -732,9 +732,9 @@ async def test_message_order_in_subscribe_unsubscribe_all_loop(
     'complete' message.
     """
 
-    NUMBER_OF_UNSUBSCRIBE_CALLS = 50  # pylint: disable=invalid-name
+    NUMBER_OF_UNSUBSCRIBE_CALLS = 100  # pylint: disable=invalid-name
     # Delay in seconds.
-    DELAY_BETWEEN_UNSUBSCRIBE_CALLS = 0.01  # pylint: disable=invalid-name
+    DELAY_BETWEEN_UNSUBSCRIBE_CALLS = 0.02  # pylint: disable=invalid-name
     # Gradually stop the test if time is up.
     TIME_BORDER = 20  # pylint: disable=invalid-name
 


### PR DESCRIPTION
This pull request adds two features:
1. Per-operation context - allows sharing any data between different calls to `Subscription.publish` for the same subscription (and the same connection).
2. Initial payload - allows sending an arbitrary "initial" response to a client as soon as it is subscribed (before any call to `Subscription.broadcast`).

I use them like so (in `schema.py`):

~~~schema.py
import channels_graphql_ws
import graphene
from channels_graphql_ws.operation_context import OperationContext
from graphene import ResolveInfo

from .task import Task

class TaskLogChanged(channels_graphql_ws.Subscription):
    class Arguments:
        id = graphene.Argument(graphene.NonNull(graphene.ID))

    content = graphene.Field(graphene.NonNull(graphene.List(graphene.NonNull(graphene.String))))
    begin = graphene.Field(graphene.NonNull(graphene.Int))
    end = graphene.Field(graphene.NonNull(graphene.Int))

    class Meta:
        initial_payload = None

    @staticmethod
    def subscribe(root: None, info: ResolveInfo, id: str) -> Optional[List[str]]:
        task = Task(id)
        return [task.uuid]

    @classmethod
    def trigger(cls, task: Task) -> None:
        cls.broadcast_sync(group=task.uuid, payload=None)

    @staticmethod
    def publish(payload: None, info: ResolveInfo, id: str) -> Union[TaskLogChanged, object]:
        assert isinstance(info.context, OperationContext)
        saved_cursor: int = info.context.operation_context.get('cursor', 0)

        task = Task(id)
        content, new_cursor = task.get_log(saved_cursor)

        if new_cursor == saved_cursor:
            assert len(list(content)) == 0
            return TaskLogChanged.SKIP
        else:
            info.context.operation_context['cursor'] = new_cursor
            return TaskLogChanged(content=content, begin=saved_cursor, end=new_cursor)
~~~
